### PR TITLE
Add support for installing a specific openedx repo and branch through tutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,39 @@ jobs:
         with:
           aws-ecr-repo: openedx
 ```
+
+```yaml
+name: Example workflow
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # required antecedent
+      - uses: actions/checkout@v3.0.2
+
+      # required antecedent
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1.6.1
+        with:
+          aws-access-key-id: ${{ secrets.THE_NAME_OF_YOUR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.THE_NAME_OF_YOUR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      # install and configure tutor and kubectl
+      - name: Configure Github workflow environment
+        uses: openedx-actions/tutor-k8s-init@v1.0.0
+
+      # This action.
+      # Note:
+      # aws-ecr-repo is optional. The default value is openedx
+      - name: Build the image and upload to AWS ECR
+        uses: openedx-actions/tutor-plugin-build-openedx@v1.0.0
+        with:
+          aws-ecr-repo: openedx
+          openedx-repository: https://github.com/openedx/edx-platform.git
+          openedx-version: main #in this casem the main branch is specified. You may also specify a tag
+```

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,14 @@ inputs:
     description: 'The name of the repository inside your AWS Elastic Container Registry (ECR) in which the newly created container will be uploaded and tagged. Defaults to "openedx"'
     required: false
     default: 'openedx'
+  openedx-repository:
+    description: 'The web url of the repository that holds the openedx code. This should only be set when using a forked version of openedx. Defaults to an empty string, which uses the tutor default'
+    required: false
+    default: ''
+  openedx-version:
+    description: 'The version of openedx to deploy. This corresponds to a branch or tag name in the openedx repository. Defaults to an empty string, which uses the tutor default'
+    required: false
+    default: ''
 outputs:
   docker-container-url:
     description: 'The URL of the AWS ECR Docker container that was created and uploaded'
@@ -86,7 +94,9 @@ runs:
     - name: Build the image
       id: tutor-build-image
       shell: bash
-      run: tutor images build openedx
+      run: |
+        tutor images build ${{ inputs.openedx-repository != '' && format('-a EDX_PLATFORM_REPOSITORY={0}', inputs.openedx-repository) || '' }} \
+          ${{ inputs.openedx-version != '' && format('-a EDX_PLATFORM_VERSION={0}', inputs.openedx-version) || '' }} openedx
 
     - name: Push the image
       id: docker-push-image


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
N/A

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->

Tutor supports specifying a custom repo (`EDX_PLATFORM_REPOSITORY`) and version (`EDX_PLATFORM_VERSION`)

This change allows users to:
1. Specify `openedx-repository` as a github web url. If specified, it will overwrite `EDX_PLATFORM_REPOSITORY`
2. Specify `openedx-version` as a branch or tag. If specified, it will overwrite `EDX_PLATFORM_REPOSITORY`

The code updates the `tutor image build` command as outlined here: https://github.com/overhangio/tutor/blob/master/docs/configuration.rst#open-edx-customisation