### PR TITLE
Fix 22 - OpenEdx Build Correct Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## Unreleased
+* [BugFix] Change EDX_PLATFORM_VERSION to OPENEDX_COMMON_VERSION
+
 ## Version 1.0.0 (2022-06-16)
 
 General production release.

--- a/action.yml
+++ b/action.yml
@@ -101,7 +101,7 @@ runs:
       shell: bash
       run: |
         tutor images build ${{ inputs.openedx-repository != '' && format('-a EDX_PLATFORM_REPOSITORY={0}', inputs.openedx-repository) || '' }} \
-          ${{ inputs.openedx-version != '' && format('-a EDX_PLATFORM_VERSION={0}', inputs.openedx-version) || '' }} openedx
+          ${{ inputs.openedx-version != '' && format('-a OPENEDX_COMMON_VERSION={0}', inputs.openedx-version) || '' }} openedx
 
     - name: Push the image
       id: docker-push-image


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes #22 

### Describe Changes
Change action to set `OPENEDX_COMMON_VERSION` instead of `EDX_PLATFORM_VERSION` when `openedx-version` is passed as a parameter.
